### PR TITLE
Track largest allocation between calls to `AccountingAlloc::count`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "accounting-allocator"
 version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
+ "crossbeam-utils",
  "once_cell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ exclude = ["/.github", ".*"]
 [dependencies]
 crossbeam-channel = "0.5.6"
 once_cell = "1.16.0"
+
+[dev-dependencies]
+crossbeam-utils = "0.8.14"

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,3 +1,14 @@
+//! Basic functionality tests using `AccountingAlloc` as the global allocator.
+//!
+//! Since it's hard to pin down exactly how much will be allocated using the global allocator in a Rust program, as Rust
+//! is allowed to (and does) allocate whatever it needs using the global allocator internally, the tests in this module
+//! mostly exist to demonstrate that the `Display` and `Debug` impls for `AccountingAlloc` don't hang, infinitely
+//! recurse, panic, or abort.
+//!
+//! On most hosts, there are some implicit assertions in the system allocator for double-free and leak detection. (Plus,
+//! we could probably explicitly add a memory sanitizer on top of that later.) There are also potentially some code
+//! paths which `abort()` inside `AccountingAlloc`, which would indicate bugs.
+
 use accounting_allocator::{AccountingAlloc, AllTimeAllocStats};
 
 use crossbeam_utils::thread::scope;

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,4 +1,4 @@
-use accounting_allocator::{AccountingAlloc, AllocCounts};
+use accounting_allocator::{AccountingAlloc, AllTimeAllocStats};
 
 use crossbeam_utils::thread::scope;
 
@@ -21,7 +21,7 @@ fn global_count() {
         .unwrap();
 
     println!("{GLOBAL_ALLOCATOR:?}");
-    let AllocCounts { alloc, dealloc, largest_alloc } = GLOBAL_ALLOCATOR.count();
+    let AllTimeAllocStats { alloc, dealloc, largest_alloc } = GLOBAL_ALLOCATOR.count().all_time;
     println!("Total: alloc {alloc} dealloc {dealloc} largest_alloc {largest_alloc}");
     println!("{GLOBAL_ALLOCATOR:?}");
 }

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,0 +1,27 @@
+use accounting_allocator::{AccountingAlloc, AllocCounts};
+
+use crossbeam_utils::thread::scope;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: AccountingAlloc = AccountingAlloc::new();
+
+#[test]
+fn global_display() {
+    scope(|scope| (0..9).for_each(|idx| drop(scope.spawn(move |_| drop(Vec::<u8>::with_capacity(10000 * idx))))))
+        .unwrap();
+
+    println!("{GLOBAL_ALLOCATOR:?}");
+    println!("{GLOBAL_ALLOCATOR}");
+    println!("{GLOBAL_ALLOCATOR:?}");
+}
+
+#[test]
+fn global_count() {
+    scope(|scope| (0..9).for_each(|idx| drop(scope.spawn(move |_| drop(Vec::<u8>::with_capacity(10000 * idx))))))
+        .unwrap();
+
+    println!("{GLOBAL_ALLOCATOR:?}");
+    let AllocCounts { alloc, dealloc, largest_alloc } = GLOBAL_ALLOCATOR.count();
+    println!("Total: alloc {alloc} dealloc {dealloc} largest_alloc {largest_alloc}");
+    println!("{GLOBAL_ALLOCATOR:?}");
+}


### PR DESCRIPTION
This adds tracking of the largest allocation between calls to `AccountingAlloc::count`. We use
[`AcqRel`](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.AcqRel) atomic ordering instead of
`Relaxed`, as we want [`fetch_max`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max) to properly respect the counter being reset from another thread. See [this crossbeam issue](https://github.com/crossbeam-rs/crossbeam/issues/317) for why `SeqCst` ordering is probably not necessary -- particularly:

> I think there is no simple code that is correct with SeqCst but wrong with release-acquire.

This PR also adds a nicer test suite.